### PR TITLE
implement so reuseaddr and so reuseport option for the listening socket

### DIFF
--- a/docs/setsockopt.md
+++ b/docs/setsockopt.md
@@ -1,0 +1,31 @@
+# `setsockopt`
+
+The `setsockopt` function allows programmers to modify the behavior of sockets through various options, from performance tweaks to behavioral modifications. It enables the adjustment of settings not accessible through standard socket creation and configuration functions.
+
+## Usage in Our Codebase
+
+In our project, `setsockopt` is employed exactly once, on the server's listening socket, immediately after the socket is created and before it is bound to an address with `bind()`. The specific options we set are `SO_REUSEADDR` and `SO_REUSEPORT`.
+
+### Syntax
+
+```c
+int setsockopt(int sockfd, int level, int optname,
+               const void *optval, socklen_t optlen);
+```
+
+- `sockfd` refers to the socket file descriptor, in our case, the listening socket.
+- `level` indicates the protocol level at which the option resides; for socket-level options, this is `SOL_SOCKET`.
+- `optname` denotes the name of the option(s) to be set; in our scenario, these are `SO_REUSEADDR` and `SO_REUSEPORT`.
+- `optval` points to the value for the option(s), essentially a pointer to an integer that could be 1 (ON) or 0 (OFF).
+- `optlen` specifies the size of the value at `optval`.
+
+### Reason for Use
+
+We utilize `setsockopt` to set the `SO_REUSEADDR` and `SO_REUSEPORT` options for several reasons:
+
+- **Rapid Restart**: Enabling `SO_REUSEADDR` allows the server to be immediately restarted after being stopped, circumventing the standard timeout expiration. This feature is invaluable during the development and testing phases, facilitating frequent server restarts via CTRL + C.
+- **Address Binding**: `SO_REUSEADDR` permits the server to bind to its designated port even if sockets from a prior server instance linger in a "TIME_WAIT" state. Absent `SO_REUSEADDR`, binding the socket might trigger an `EADDRINUSE` error due to the address being perceived as already in use.
+- **Efficient Resource Utilization**: These settings optimize resource utilization, ensuring server resources (such as ports) are promptly reusable, sidestepping delays associated with residual socket states.
+- **Load Balancing and Redundancy**: `SO_REUSEPORT` allows multiple server instances to bind to the same port concurrently, facilitating load distribution and redundancy without the traditional `EADDRINUSE` errors.
+
+These configurations, while seemingly minor optimizations, contribute significantly to the operational flexibility and efficiency of our server, enhancing its development lifecycle and runtime performance.

--- a/main.cpp
+++ b/main.cpp
@@ -97,7 +97,7 @@ int main()
 	}
 	while (1)
 	{
-		printf("\n+++++++ Waiting for new connection ++++++++\n\n");
+		std::cout << "\n+++++++ Waiting for new connection ++++++++\n\n";
 		if ((new_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t *)&addrlen)) < 0)
 		{
 			perror("In accept");
@@ -114,7 +114,7 @@ int main()
 		printf("%s\n", buffer);
 		// Respond to the request with some HTML
 		write(new_socket, returnHTML(), strlen(returnHTML()));
-		printf("------------------HTML message sent-------------------\n");
+		std::cout << "------------------HTML message sent-------------------" << std::endl;
 
 		close(new_socket);
 	}

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,21 @@ const char *returnHTML()
 		   "</html>";
 }
 
+void *ft_memset(void *ptr, int value, size_t num)
+{
+	// Cast the pointer to a char pointer, as we're dealing with bytes
+	unsigned char *p = static_cast<unsigned char *>(ptr);
+
+	// Fill the specified memory area with the given value
+	for (size_t i = 0; i < num; ++i)
+	{
+		p[i] = static_cast<unsigned char>(value);
+	}
+
+	// Return the original pointer
+	return ptr;
+}
+
 int main()
 {
 	int server_fd, new_socket;
@@ -68,7 +83,7 @@ int main()
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
-	memset(address.sin_zero, '\0', sizeof address.sin_zero);
+	ft_memset(address.sin_zero, '\0', sizeof address.sin_zero);
 
 	if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
 	{

--- a/main.cpp
+++ b/main.cpp
@@ -110,7 +110,7 @@ int main()
 			exit(EXIT_FAILURE);
 		}
 		std::cout << "Received http request: " << std::endl << buffer << std::endl;
-		printf("%s\n", buffer);
+		std::cout << buffer << std::endl;
 		// Respond to the request with some HTML
 		write(new_socket, returnHTML(), strlen(returnHTML()));
 		std::cout << "------------------HTML message sent-------------------" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include <cstdlib> // For exit() and EXIT_FAILURE
-#include <cstring> // For memset
 #include <iostream>
 #include <netinet/in.h> // For sockaddr_in
 #include <sys/socket.h> // For socket functions

--- a/main.cpp
+++ b/main.cpp
@@ -47,6 +47,24 @@ int main()
 		exit(EXIT_FAILURE);
 	}
 
+	int opt = 1;
+	// Set SO_REUSEADDR to allow re-binding to the same address and port
+
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)))
+	{
+		perror("setsockopt");
+		exit(EXIT_FAILURE);
+	}
+
+	// Try to set SO_REUSEPORT
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)))
+	{
+		perror("setsockopt SO_REUSEPORT: Protocol not available, continuing without SO_REUSEPORT");
+		// Don't exit on failure; it's not critical for basic server functionality
+		// Setting SO_REUSEPORT is not supported on all systems and setting it on the same call was causing the server
+		// to fail
+	}
+
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);


### PR DESCRIPTION
- super small optimisation that anyone has (see new doc about setsockopt, which will be used only once)
- plus rewritten memset (not allowed) but many have in their code
- plus replace printfs with std::cout