### PR TITLE
slombard/web 175 fix multiple reads headers and body after poll

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -69,9 +69,9 @@ Parser &Connection::getParser()
 	return _parser;
 }
 // Attempts to read HTTP request headers from the client connection into _headersBuffer on the Parser.
-bool Connection::readSocket(Parser &parser)
+bool Connection::readHeaders(Parser &parser)
 {
-	std::cout << "\nEntering readSocket" << std::endl;
+	std::cout << "\nEntering readHeaders" << std::endl;
 	char buffer[BUFFER_SIZE] = {0};
 	std::cout << "buffers size: " << sizeof(buffer) << std::endl;
 	ssize_t bytesRead = recv(_pollFd.fd, buffer, BUFFER_SIZE, 0);
@@ -81,7 +81,7 @@ bool Connection::readSocket(Parser &parser)
 		parser.setBuffer(parser.getBuffer() + std::string(buffer, bytesRead));
 		std::cout << "The buffer is: " << parser.getBuffer() << std::endl;
 
-		std::cout << "Exiting readSocket" << std::endl;
+		std::cout << "Exiting readHeaders" << std::endl;
 		return true;
 	}
 	else if (bytesRead < 0)
@@ -96,7 +96,7 @@ bool Connection::readSocket(Parser &parser)
 	}
 	else
 	{
-		std::cout << "Exiting readSocket. This will never happen here!" << std::endl;
+		std::cout << "Exiting readHeaders. This will never happen here!" << std::endl;
 		return true;
 	}
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -89,13 +89,16 @@ bool Connection::readSocket(Parser &parser)
 		perror("recv failed");
 		return false;
 	}
-	else
+	else if (bytesRead == 0)
 	{
 		std::cout << "Connection closed before headers being completely sent" << std::endl;
 		return false;
 	}
-	std::cout << "Exiting readSocket. This will never happen here!" << std::endl;
-	return true;
+	else
+	{
+		std::cout << "Exiting readSocket. This will never happen here!" << std::endl;
+		return true;
+	}
 }
 // About the hexa conversion
 // Convert the hexadecimal string from `chunkSizeLine` to a size_t value.

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -28,7 +28,7 @@ class Connection
 	Connection &operator=(const Connection &other); // Copy assignment operator
 	~Connection();
 
-	bool readSocket(Parser &parser);
+	bool readHeaders(Parser &parser);
 	bool readChunkedBody(Parser &parser);
 	bool readChunkSize(std::string &line);
 	bool readChunk(size_t chunkSize, std::string &chunkedData, HTTPResponse &response);

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -19,21 +19,24 @@ Parser::~Parser()
 
 bool Parser::preParseHeaders(HTTPResponse &res)
 {
-	// We read the buffer with readSocket if headersComplete is not true and we write the buffer in the _headersBuffer
+	// We read the buffer with readHeaders if headersComplete is not true and we write the buffer in the _headersBuffer
 	std::size_t headersEnd = _buffer.find("\r\n\r\n");
 	if (headersEnd != std::string::npos)
 	{
 		_headersBuffer = _buffer.substr(0, headersEnd + 4);
-		std::cout << "\033[31m" << "_headersBuffer size " << _headersBuffer.size() << "\033[0m" << std::endl;
+		std::cout << "\033[31m"
+				  << "_headersBuffer size " << _headersBuffer.size() << "\033[0m" << std::endl;
 		std::cout << "_headersBuffer:" << std::endl;
 		std::cout << _headersBuffer << std::endl;
 		_headersComplete = true;
-		std::cout << "\033[31m" << "_buffer size " << _buffer.size() << "\033[0m" << std::endl;
+		std::cout << "\033[31m"
+				  << "_buffer size " << _buffer.size() << "\033[0m" << std::endl;
 		std::cout << "_headersBuffer size:" << std::endl;
 		std::cout << _headersBuffer.size() << std::endl;
 		_buffer = _buffer.substr(headersEnd + 4);
 		std::cout << _buffer << std::endl;
-		std::cout << "\033[31m" << "_buffer size " << _buffer.size() << "\033[0m" << std::endl;
+		std::cout << "\033[31m"
+				  << "_buffer size " << _buffer.size() << "\033[0m" << std::endl;
 		return (true);
 	}
 	if (_buffer.length() > CLIENT_MAX_HEADERS_SIZE)
@@ -264,14 +267,16 @@ int Parser::fileHeaderParametrs(const std::string &headers, struct File &file, u
 		if (headers[++i] == '=') // [=]
 		{
 			key = headers.substr(start, i - start); // [KEY]
-			std::cout << "\033[31m" << "Params Key: " << key << "\033[0m" << std::endl;
+			std::cout << "\033[31m"
+					  << "Params Key: " << key << "\033[0m" << std::endl;
 			if (headers[++i] != '"') // ["]
 				return (0);
 			start = ++i; // skip '"'
 			while (i < headers.length() && headers[i] != '"')
 				i++;
 			value = headers.substr(start, i - start); // [VALUE]
-			std::cout << "\033[31m" << "Params Value: " << value << "\033[0m" << std::endl;
+			std::cout << "\033[31m"
+					  << "Params Value: " << value << "\033[0m" << std::endl;
 			if (headers[i++] != '"') // ["]
 				return (0);
 			file.headers.insert(std::make_pair(key, value));

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -187,6 +187,7 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 	response = router.routeRequest(request);
 	responseString = response.objToString();
 	std::cout << "\033[1;91mResponse: " << responseString << "\033[0m" << std::endl;
+	// TODO: we should not send here but go through poll first and check for POLLOUT
 	write(conn.getPollFd().fd, responseString.c_str(), responseString.size());
 	close(conn.getPollFd().fd);
 	_FDs.erase(_FDs.begin() + i);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -183,6 +183,7 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 	response = conn.getResponse();
 	std::cout << std::endl << "DEBUG" << std::endl;
 	std::cout << request.getRequestTarget() << std::endl;
+	// TODO: The Router should be a member of the Server class or of the Connection class
 	Router router;
 	response = router.routeRequest(request);
 	responseString = response.objToString();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -131,11 +131,12 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 		std::cout << "Error: " << response.getStatusCode() << std::endl;
 	else if (request.getMethod() == "GET")
 	{
+		// TODO; consider the fact that we could potentially have a body in the GET request and in the socket
+		// Should we 'consume' it?
 		std::cout << "GET request, no body to read" << std::endl;
 	}
 	else
 	{
-
 		if (parser.getIsChunked())
 		{
 			std::cout << "Chunked body" << std::endl;
@@ -147,7 +148,7 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 			std::cout << "\033[1;33m"
 					  << "Regular body"
 					  << "\033[0m" << std::endl;
-			if (parser.getBuffer().size() == request.getContentLength())
+			if (!parser.getBodyComplete() && parser.getBuffer().size() == request.getContentLength())
 				parser.setBodyComplete(true);
 			else if (!conn.readBody(parser, request, response))
 			{

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -129,6 +129,10 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 		parser.parseRequestLineAndHeaders(parser.getHeadersBuffer().c_str(), request, response);
 	if (response.getStatusCode() != 0)
 		std::cout << "Error: " << response.getStatusCode() << std::endl;
+	else if (request.getMethod() == "GET")
+	{
+		std::cout << "GET request, no body to read" << std::endl;
+	}
 	else
 	{
 
@@ -145,14 +149,12 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 					  << "\033[0m" << std::endl;
 			if (parser.getBuffer().size() == request.getContentLength())
 				parser.setBodyComplete(true);
-			else if (request.getMethod() == "GET")
-				std::cout << "GET request, no body to read" << std::endl;
 			else if (!conn.readBody(parser, request, response))
 			{
 				return (std::cout << "Error reading body" << std::endl, closeClientConnection(conn, i));
 			}
 		}
-		if (request.getMethod() != "GET" && !parser.getBodyComplete())
+		if (!parser.getBodyComplete())
 		{
 			std::cout << "Body still incomplete, exiting handleConnection." << std::endl;
 			return;
@@ -166,7 +168,7 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 	}
 
 	std::cout << "\033[1;91mRequest: " << response.getStatusCode() << "\033[0m" << std::endl;
-	if (response.getStatusCode() != 0)
+	if (response.getStatusCode() != 0 || request.getMethod() == "GET")
 	{
 		response.setErrorResponse(response.getStatusCode());
 		std::string responseString = response.objToString();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -106,16 +106,23 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 	if (!parser.getHeadersComplete())
 	{
 		if (!conn.readSocket(parser))
-			return (std::cout << "Error reading headers" << std::endl, closeClientConnection(conn, i));
+		{
+			std::cout << "Error reading headers" << std::endl;
+			closeClientConnection(conn, i);
+			return;
+		}
 		if (!parser.preParseHeaders(response))
 		{
+			// TODO: we should not send here but go through poll first and check for POLLOUT
 			send(conn.getPollFd().fd, response.objToString().c_str(), response.objToString().size(), 0);
-			return (std::cout << "Error pre-parsing headers" << std::endl, closeClientConnection(conn, i));
+			std::cout << "Error pre-parsing headers" << std::endl;
+			closeClientConnection(conn, i);
+			return;
 		}
 	}
 	if (!parser.getHeadersComplete())
 	{
-		std::cout << "Headers incomplete, exiting handleConnection." << std::endl;
+		std::cout << "Headers incomplete yet, exiting handleConnection." << std::endl;
 		return;
 	}
 	if (parser.getHeadersComplete() && !parser.getHeadersAreParsed())

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -180,7 +180,6 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 	}
 
 	std::string responseString;
-	response = conn.getResponse();
 	std::cout << std::endl << "DEBUG" << std::endl;
 	std::cout << request.getRequestTarget() << std::endl;
 	// TODO: The Router should be a member of the Server class or of the Connection class

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -106,7 +106,7 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 
 	if (!parser.getHeadersComplete())
 	{
-		if (!conn.readSocket(parser))
+		if (!conn.readHeaders(parser))
 		{
 			std::cout << "Error reading headers" << std::endl;
 			closeClientConnection(conn, i);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -140,9 +140,9 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 		}
 		else
 		{
-			std::cout << "\033[1;33m";
-			std::cout << "Regular body" << std::endl;
-			std::cout << "\033[0m";
+			std::cout << "\033[1;33m"
+					  << "Regular body"
+					  << "\033[0m" << std::endl;
 			if (parser.getBuffer().size() == request.getContentLength())
 				parser.setBodyComplete(true);
 			else if (request.getMethod() == "GET")


### PR DESCRIPTION
My suggestion on how to solve the problem of the multiple readings. It's not tested. 

I added an extra variable in handleConnection socketHasBeenRead, which is set to false everytime the function is called. ReadSocket will change it to true when the headers are read, and read body will read the body only if the body is not complete and the socket has not been already read. 

I'll also change the name of readSocket into readHeaders (which was the original name). I was thinking I could use just 1 function to read headers and body but it was too complicated to implement it. 