### PR TITLE
add secretus repo as 'private' submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secretus"]
+	path = secretus
+	url = git@github.com:552020/webserv_secretus.git


### PR DESCRIPTION
This PR is related on how to manage 'sensitive' info. I created a private repo to which you've been invited and then added this repo as submodule of this repo, so only you (after you will accept the invitation to that repo) will be able to clone the repo as submodule. In the private repo in the README there is an explanation on how to do this. The private repo has other repos wich are submodules of that repo. This private repo is .gitignored so maybe you will need to use --force to clone it when using the recursive flag