### PR TITLE
fix logic in the for loop of poll

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -38,7 +38,11 @@ void Server::startPollEventLoop()
 		int ret = poll(_FDs.data(), _FDs.size(), -1);
 		if (ret > 0)
 		{
-			for (size_t i = 0; i < _FDs.size(); i++)
+			size_t originalSize = _FDs.size();
+			// if _FDs becomes bigger than originalSize we don't want to loop over the new elements before we finish the
+			// old ones if _FDs becomes smaller than originalSize we don't want to loop over the old elements that are
+			// not in _FDs anymore
+			for (size_t i = 0; i < originalSize && i < _FDs.size(); i++)
 			{
 				if (_FDs[i].revents & (POLLIN | POLLOUT))
 				{


### PR DESCRIPTION
Small fix in the logic of the for loop for poll. 

If we add a socket into the _FDs vector we don't want to evaluate that socket before we went to poll again (so we are using the actualSize). But if we remove a socket from the _FDs vector we don't want to use actualSize (which would be bigger) but the size of FDs. 
Basically we loop till to the smaller of the two now.