### PR TITLE
Add type of socket in the connection objects, plus ip, port and implement logic to assign the values

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -5,6 +5,9 @@ Connection::Connection(struct pollfd &pollFd, Server &server)
 {
 	(void)server;
 	_pollFd.fd = pollFd.fd;
+	_type = UNDEFINED;
+	_serverIp = "";
+	_serverPort = 0;
 	_pollFd.events = POLLIN;
 	_pollFd.revents = 0;
 	_hasReadSocket = false;
@@ -20,6 +23,9 @@ Connection::Connection(const Connection &other)
 	_response = other._response;
 	_request = other._request;
 	_parser = other._parser;
+	_type = other._type;
+	_serverIp = other._serverIp;
+	_serverPort = other._serverPort;
 	_hasReadSocket = other._hasReadSocket;
 	_hasFinishedReading = other._hasFinishedReading;
 	_hasDataToSend = other._hasDataToSend;
@@ -37,6 +43,9 @@ Connection &Connection::operator=(const Connection &other)
 		_response = other._response;
 		_request = other._request;
 		_parser = other._parser;
+		_type = other._type;
+		_serverIp = other._serverIp;
+		_serverPort = other._serverPort;
 		_hasReadSocket = other._hasReadSocket;
 		_hasFinishedReading = other._hasFinishedReading;
 		_hasDataToSend = other._hasDataToSend;
@@ -63,10 +72,7 @@ Connection::~Connection()
 
 // GETTERS AND SETTERS
 
-struct pollfd Connection::getPollFd() const
-{
-	return _pollFd;
-}
+// GETTERS
 
 HTTPResponse &Connection::getResponse()
 {
@@ -82,23 +88,9 @@ Parser &Connection::getParser()
 	return _parser;
 }
 
-bool Connection::getHasReadSocket()
+struct pollfd Connection::getPollFd() const
 {
-	return _hasReadSocket;
-}
-
-bool Connection::getHasFinishedReading()
-{
-	return _hasFinishedReading;
-}
-
-bool Connection::getHasDataToSend()
-{
-	return _hasDataToSend;
-}
-bool Connection::getHasFinishedSending()
-{
-	return _hasFinishedSending;
+	return _pollFd;
 }
 
 struct pollfd &Connection::getPollFd()
@@ -106,9 +98,60 @@ struct pollfd &Connection::getPollFd()
 	return _pollFd;
 }
 
-bool Connection::getCanBeClosed()
+enum ConnectionType Connection::getType() const
+{
+	return _type;
+}
+
+std::string Connection::getServerIp() const
+{
+	return _serverIp;
+}
+
+unsigned short Connection::getServerPort() const
+{
+	return _serverPort;
+}
+
+bool Connection::getHasReadSocket() const
+{
+	return _hasReadSocket;
+}
+
+bool Connection::getHasFinishedReading() const
+{
+	return _hasFinishedReading;
+}
+
+bool Connection::getHasDataToSend() const
+{
+	return _hasDataToSend;
+}
+bool Connection::getHasFinishedSending() const
+{
+	return _hasFinishedSending;
+}
+
+bool Connection::getCanBeClosed() const
 {
 	return _canBeClosed;
+}
+
+// SETTERS
+
+void Connection::setType(enum ConnectionType type)
+{
+	_type = type;
+}
+
+void Connection::setServerIp(std::string serverIp)
+{
+	_serverIp = serverIp;
+}
+
+void Connection::setServerPort(unsigned short serverPort)
+{
+	_serverPort = serverPort;
 }
 
 void Connection::setHasReadSocket(bool value)
@@ -139,7 +182,7 @@ void Connection::setCanBeClosed(bool value)
 {
 	_canBeClosed = value;
 }
-// Attempts to read HTTP request headers from the client connection into _headersBuffer on the Parser.
+
 bool Connection::readHeaders(Parser &parser)
 {
 	// std::cout << "\nEntering readHeaders" << std::endl;

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -18,6 +18,8 @@ Connection::Connection(const Connection &other)
 {
 	_pollFd = other._pollFd;
 	_response = other._response;
+	_request = other._request;
+	_parser = other._parser;
 	_hasReadSocket = other._hasReadSocket;
 	_hasFinishedReading = other._hasFinishedReading;
 	_hasDataToSend = other._hasDataToSend;
@@ -33,6 +35,13 @@ Connection &Connection::operator=(const Connection &other)
 	{
 		_pollFd = other._pollFd;
 		_response = other._response;
+		_request = other._request;
+		_parser = other._parser;
+		_hasReadSocket = other._hasReadSocket;
+		_hasFinishedReading = other._hasFinishedReading;
+		_hasDataToSend = other._hasDataToSend;
+		_hasFinishedSending = other._hasFinishedSending;
+		_canBeClosed = other._canBeClosed;
 	}
 	std::cout << "Connection object assigned" << std::endl;
 	return *this;

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -10,6 +10,13 @@
 #include "HTTPResponse.hpp" // Assuming existence of HTTPResponse class
 #include "Parser.hpp"		// Assuming existence of Parser class
 
+enum ConnectionType
+{
+	UNDEFINED,
+	CLIENT,
+	SERVER,
+};
+
 class Server; // Forward declaration for circular dependency
 
 class Connection
@@ -20,6 +27,9 @@ class Connection
 	HTTPResponse _response;
 
 	struct pollfd _pollFd;
+	enum ConnectionType _type;
+	std::string _serverIp;
+	unsigned short _serverPort;
 	bool _hasReadSocket;
 	bool _hasFinishedReading;
 	bool _hasDataToSend;
@@ -42,22 +52,27 @@ class Connection
 	Parser &getParser();
 	HTTPRequest &getRequest();
 	HTTPResponse &getResponse();
+
 	struct pollfd getPollFd() const;
-	bool getHasReadSocket();
-	bool getBodyComplete() const;
-	std::string getChunkData() const;
-	bool getHasFinishedReading();
-	bool getHasDataToSend();
-	bool getHasFinishedSending();
-	bool getCanBeClosed();
+
+	enum ConnectionType getType() const;
+	std::string getServerIp() const;
+	unsigned short getServerPort() const;
+
+	bool getHasReadSocket() const;
+	bool getHasFinishedReading() const;
+	bool getHasDataToSend() const;
+	bool getHasFinishedSending() const;
+	bool getCanBeClosed() const;
+
 	struct pollfd &getPollFd();
 
 	/* Setters */
+	void setType(enum ConnectionType type);
+	void setServerIp(std::string serverIp);
+	void setServerPort(unsigned short serverPort);
+
 	void setHasReadSocket(bool value);
-	void setHeadersComplete(bool headersComplete);
-	void setBodyComplete(bool bodyComplete);
-	void setHeaders(const std::string &headers);
-	void setChunkData(const std::string &chunkData);
 	void setHasFinishedReading(bool value);
 	void setCanBeClosed(bool value);
 	void setHasDataToSend(bool value);

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -26,12 +26,10 @@ class Connection
 	bool _hasFinishedSending;
 	bool _canBeClosed;
 
-	// Additional client state can be managed here
-
   public:
 	Connection(struct pollfd &pollFd, Server &server);
-	Connection(const Connection &other);			// Copy constructor
-	Connection &operator=(const Connection &other); // Copy assignment operator
+	Connection(const Connection &other);
+	Connection &operator=(const Connection &other);
 	~Connection();
 
 	bool readHeaders(Parser &parser);
@@ -64,7 +62,6 @@ class Connection
 	void setCanBeClosed(bool value);
 	void setHasDataToSend(bool value);
 	void setHasFinishedSending(bool value);
-	// We will not provide the setter for HTTPResponse as it should be managed by the HTTPResponse class
 	/* Debugging */
 	void printConnection() const;
 };

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -5,6 +5,33 @@ HTTPRequest::HTTPRequest()
 {
 }
 
+HTTPRequest::HTTPRequest(const HTTPRequest &obj)
+{
+	_method = obj._method;
+	_requestTarget = obj._requestTarget;
+	_protocolVersion = obj._protocolVersion;
+	_queryString = obj._queryString;
+	_headers = obj._headers;
+	_body = obj._body;
+	_uploadBoundary = obj._uploadBoundary;
+	_files = obj._files;
+}
+
+HTTPRequest &HTTPRequest::operator=(const HTTPRequest &obj)
+{
+	if (this == &obj)
+		return (*this);
+	_method = obj._method;
+	_requestTarget = obj._requestTarget;
+	_protocolVersion = obj._protocolVersion;
+	_queryString = obj._queryString;
+	_headers = obj._headers;
+	_body = obj._body;
+	_uploadBoundary = obj._uploadBoundary;
+	_files = obj._files;
+	return (*this);
+}
+
 HTTPRequest::~HTTPRequest()
 {
 }

--- a/src/HTTPRequest.hpp
+++ b/src/HTTPRequest.hpp
@@ -11,6 +11,8 @@ class HTTPRequest
   public:
 	HTTPRequest();
 	~HTTPRequest();
+	HTTPRequest(const HTTPRequest &obj);
+	HTTPRequest &operator=(const HTTPRequest &obj);
 
 	// GETTERS
 	std::string getMethod() const;
@@ -37,9 +39,6 @@ class HTTPRequest
 	void setFileContent(const std::string &content);
 
   private:
-	HTTPRequest(const HTTPRequest &obj);
-	HTTPRequest &operator=(const HTTPRequest &obj);
-
 	// VARIABLES
 	std::string _method;
 	std::string _requestTarget;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -51,7 +51,7 @@ void Server::startPollEventLoop()
 					if (i == 0)
 					{
 						std::cout << "Server socket event" << std::endl;
-						acceptNewConnection();
+						acceptNewConnection(_connections[i]);
 					}
 					else
 					{
@@ -375,10 +375,13 @@ void Server::addServerSocketPollFdToVectors()
 	serverPollFd.revents = 0;
 	_FDs.push_back(serverPollFd);
 	Connection serverConnection(serverPollFd, *this);
+	serverConnection.setType(SERVER);
+	serverConnection.setServerIp(inet_ntoa(_serverAddr.sin_addr));
+	serverConnection.setServerPort(ntohs(_serverAddr.sin_port));
 	_connections.push_back(serverConnection);
 }
 
-void Server::acceptNewConnection()
+void Server::acceptNewConnection(Connection &conn)
 {
 	// TODO: think about naming.
 	// We have 4 different names for kind of the same thing: clientAddress, newSocket, newSocketPoll,
@@ -386,7 +389,8 @@ void Server::acceptNewConnection()
 	struct sockaddr_in clientAddress;
 	socklen_t ClientAddrLen = sizeof(clientAddress);
 	std::cout << "New connection detected" << std::endl;
-	int newSocket = accept(_serverFD, (struct sockaddr *)&clientAddress, (socklen_t *)&ClientAddrLen);
+	// int newSocket = accept(_serverFD, (struct sockaddr *)&clientAddress, (socklen_t *)&ClientAddrLen);
+	int newSocket = accept(conn.getPollFd().fd, (struct sockaddr *)&clientAddress, (socklen_t *)&ClientAddrLen);
 	if (newSocket >= 0)
 	{
 		struct pollfd newSocketPoll;
@@ -394,6 +398,9 @@ void Server::acceptNewConnection()
 		newSocketPoll.events = POLLIN;
 		newSocketPoll.revents = 0;
 		Connection newConnection(newSocketPoll, *this);
+		newConnection.setType(CLIENT);
+		newConnection.setServerIp(conn.getServerIp());
+		newConnection.setServerPort(conn.getServerPort());
 		/* start together */
 		_FDs.push_back(newSocketPoll);
 		_connections.push_back(newConnection);

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -66,7 +66,7 @@ class Server
 	void listen();
 	/* for startPollEventLoop */
 	void addServerSocketPollFdToVectors();
-	void acceptNewConnection();
+	void acceptNewConnection(Connection &conn);
 	void handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPRequest &request, HTTPResponse &response);
 	void handleServerSocketError();
 	void handleClientSocketError(int clientFD, size_t &i);


### PR DESCRIPTION
I tweaked a little bit the Connection object. 

Now Connection objects have a type (UNDEFINED, SERVER, CLIENT), they have an `_ipAddress` property, which is an std::string, and they have an `_ipPort` property. 

The Server Connection objects get this properties from the _serverAddr sockaddr_in struct on the Server. 
The Server Connections get the values from the Server Connection objects that hold the data of the _serverFd which created them. The setup is still for just 1 server socket, but when the SeverBlock vector is ready, so that from each block isit possible to retrieve the ipaddress (as a string) and the port (as unsigned short) then the multi server socket capabilities can be implemented. 