### PR TITLE
Fix: add template to add imported issues to Linear'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 !**/*.json
 !**/*.jpg
 !**/*.yml
+!**/*.csv
 
 # Specific files and directories to include
 !Makefile

--- a/experiments/issues.csv
+++ b/experiments/issues.csv
@@ -1,0 +1,21 @@
+Summary,Issue key,Issue id,Issue Type,Status,Project key,Project name,Creator,Created,Updated
+Fix the issue,Issue11,11,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue12,12,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue13,13,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue14,14,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue15,15,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue16,16,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue17,17,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue18,18,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue19,19,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue20,20,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue21,21,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue22,22,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue23,23,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue24,24,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue25,25,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue26,26,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue27,27,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue28,28,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue29,29,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10
+Fix the issue,Issue30,30,Bug,Backlog,GH123,ExampleProject,slombard,2024-05-10,2024-05-10


### PR DESCRIPTION
This is the template to create new imported issue (as we would import them to Jira) which will not count for the limit. The id of the issue should be edited, otherwise they will be a sort of duplicate and Linear will not import them. 