### PR TITLE
fix(HTTPRequest): small overflow on mac in setRequestTarget if the target is an empty string

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -130,7 +130,7 @@ void HTTPRequest::setMethod(std::string method)
 
 void HTTPRequest::setRequestTarget(std::string requestTarget)
 {
-	if (requestTarget != "/" && requestTarget[requestTarget.size() - 1] == '/')
+	if (!requestTarget.empty() && requestTarget != "/" && requestTarget.back() == '/')
 		requestTarget = requestTarget.substr(0, requestTarget.size() - 1);
 	_requestTarget = requestTarget;
 }

--- a/webserv_default.conf
+++ b/webserv_default.conf
@@ -25,3 +25,10 @@ server {
 	autoindex off;
 	root var/;
 }
+
+server {
+	listen 8080;
+	server_name www.php_site;
+	allow_methods GET POST DELETE;
+	root var/;
+}


### PR DESCRIPTION
I also added in the defaut config file a server block for our php_site.