### PR TITLE
Slombard/web 312 add ipv6 addressees to the multi server test

### DIFF
--- a/multiIPv4+IPv6.conf
+++ b/multiIPv4+IPv6.conf
@@ -1,0 +1,20 @@
+server {
+	listen 0.0.0.0:8081;
+	listen [::]:8081;
+	server_name www.development_site;
+	root /var/www/html;
+}
+
+server {
+	listen 127.0.0.1:8080;
+	listen [::1]:8080;
+	server_name www.saladbook;
+	root /var/www/html;
+}
+
+server {
+	listen 127.0.0.1:8082;
+	listen [::1]:8082;
+	server_name www.python_site.com;
+	root /var/www/html;
+}

--- a/multiIPv4.conf
+++ b/multiIPv4.conf
@@ -1,0 +1,17 @@
+server {
+	listen 0.0.0.0:8081;
+	server_name www.development_site;
+	root /var/www/html;
+}
+
+server {
+	listen 127.0.0.1:8080;
+	server_name www.saladbook;
+	root /var/www/html;
+}
+
+server {
+	listen 127.0.0.1:8082;
+	server_name www.python_site.com;
+	root /var/www/html;
+}

--- a/multiIPv6.conf
+++ b/multiIPv6.conf
@@ -1,0 +1,17 @@
+server {
+	listen [::]:8081;
+	server_name www.development_site;
+	root /var/www/html;
+}
+
+server {
+	listen [::1]:8080;
+	server_name www.saladbook;
+	root /var/www/html;
+}
+
+server {
+	listen [::1]:8082;
+	server_name www.python_site.com;
+	root /var/www/html;
+}

--- a/multi_mixed.conf
+++ b/multi_mixed.conf
@@ -1,0 +1,17 @@
+server {
+	listen 0.0.0.0:8081;
+	server_name www.development_site;
+	root /var/www/html;
+}
+
+server {
+	listen [::1]:8080;
+	server_name www.saladbook;
+	root /var/www/html;
+}
+
+server {
+	listen [::1]:8082;
+	server_name www.python_site.com;
+	root /var/www/html;
+}

--- a/tests/multi_sockets/Dockerfile
+++ b/tests/multi_sockets/Dockerfile
@@ -30,7 +30,9 @@ RUN make
 WORKDIR /app/tests/multi_sockets
 
 # Make the test script executable
-RUN chmod +x test.sh
+RUN chmod +x testIPv4.sh
+RUN chmod +x testIPv6.sh
+RUN chmod +x testIPv4+IPv6.sh 
 
-# Command to start the server and run tests
-CMD ["./test.sh"]
+# Just start the shell
+CMD ["/bin/bash"]

--- a/tests/multi_sockets/Dockerfile
+++ b/tests/multi_sockets/Dockerfile
@@ -3,23 +3,13 @@ FROM ubuntu:20.04
 
 # Install necessary packages
 RUN apt-get update && \
-    apt-get install -y build-essential curl vim
+    apt-get install -y build-essential curl vim iproute2 net-tools
 
 # Set the working directory
 WORKDIR /app
 
-# Copy the entire project into the container
+# Copy the entire project into the containerenet-tools
 COPY . .  
-
-
-# List the contents of the /app directory to verify the presence of the Makefile
-RUN echo "Contents of /app:" && ls -al /app
-
-# List the contents of the tests directory to verify the structure
-RUN echo "Contents of /app/tests:" && ls -al /app/tests
-
-# List the contents of the multi_sockets directory to verify the structure
-RUN echo "Contents of /app/tests/multi_sockets:" && ls -al /app/tests/multi_sockets
 
 # Compile the project in the root directory where the Makefile is located
 RUN make re -C /app
@@ -33,6 +23,12 @@ WORKDIR /app/tests/multi_sockets
 RUN chmod +x testIPv4.sh
 RUN chmod +x testIPv6.sh
 RUN chmod +x testIPv4+IPv6.sh 
+RUN chmod +x test_mixed.sh
+
+# Enable IPv6 in the container
+RUN sysctl -w net.ipv6.conf.all.disable_ipv6=0 && \
+    sysctl -w net.ipv6.conf.default.disable_ipv6=0 && \
+    sysctl -w net.ipv6.conf.lo.disable_ipv6=0
 
 # Just start the shell
 CMD ["/bin/bash"]

--- a/tests/multi_sockets/multi_socket.md
+++ b/tests/multi_sockets/multi_socket.md
@@ -21,6 +21,40 @@ We send requests to:
 - `127.0.0.3:8080`: "000"
 - `127.0.0.1:8081`: "404"
 
+### Docker IPv6 Setup Guide
+
+#### 0. Enable IPv6 in Docker
+
+To enable IPv6 support in Docker, follow these steps:
+
+1. **Edit Docker daemon configuration**:
+   Edit the `/etc/docker/daemon.json` file to include the necessary IPv6 parameters:
+
+   ```json
+   {
+     "ipv6": true,
+     "fixed-cidr-v6": "2001:db8:1::/64",
+     "experimental": true,
+     "ip6tables": true
+   }
+   ```
+
+   Step 1 on Mac needs to be done in the Desktop app > Settings > Engine
+
+2. **Restart Docker**:
+   Save the configuration file and restart the Docker daemon for the changes to take effect:
+
+   ```sh
+   sudo systemctl restart docker
+   ```
+
+3. **Create an IPv6 network**:
+   Create a Docker network that uses IPv6:
+
+   ```sh
+   docker network create --ipv6 --subnet 2001:db8:1::/64 ip6net
+   ```
+
 #### 1. Build the Docker Image
 
 From the root of `webserv`:

--- a/tests/multi_sockets/results.txt
+++ b/tests/multi_sockets/results.txt
@@ -1,0 +1,9 @@
+127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
+127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m

--- a/tests/multi_sockets/results.txt
+++ b/tests/multi_sockets/results.txt
@@ -1,9 +1,0 @@
-127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-127.0.0.1:8080 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-0.0.0.0:8081 - Expected 404 - HTTP status code: 404 [0;32m✔[0m
-127.0.0.1:8082 - Expected 404 - HTTP status code: 404 [0;32m✔[0m

--- a/tests/multi_sockets/testIPv4+IPv6.sh
+++ b/tests/multi_sockets/testIPv4+IPv6.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if the webserv binary exists
+if [ ! -f ./../../webserv ]; then
+    echo -e "${RED}Error: webserv binary not found!${NC}"
+    exit 1
+fi
+
+echo "Starting test script..."
+
+# Modify /etc/hosts to add the new localhost aliases
+echo "127.0.0.2 localhost2" >> /etc/hosts
+echo "127.0.0.3 localhost3" >> /etc/hosts
+echo "::2 localhost2" >> /etc/hosts
+echo "::3 localhost3" >> /etc/hosts
+
+# Start the server
+echo "Starting the server..."
+./../../webserv ./../../multiIPv4+IPv6.conf &
+SERVER_PID=$!
+sleep 2  # Wait for the server to start
+
+# Check if the server started successfully
+if ! ps -p $SERVER_PID > /dev/null; then
+    echo -e "${RED}Failed to start the server.${NC}"
+    exit 1
+fi
+
+# Function to store response
+store_response() {
+    local url=$1
+    local expected=$2
+    local response=$(curl -s -o /dev/null -w "%{http_code}" $url)
+    if [ "$response" == "$expected" ]; then
+        echo -e "$url - Expected $expected - HTTP status code: $response ${GREEN}✔${NC}" >> results.txt
+    else
+        echo -e "$url - Expected $expected - HTTP status code: $response ${RED}✘${NC}" >> results.txt
+    fi
+}
+
+# Run curl commands and store responses
+store_response "127.0.0.1:8080" "404"
+store_response "0.0.0.0:8081" "404"
+store_response "127.0.0.1:8082" "404"
+store_response "127.0.0.2:8080" "000"
+store_response "127.0.0.3:8080" "000"
+store_response "127.0.0.1:8081" "404"
+store_response "[::1]:8080" "404"
+store_response "[::]:8081" "404"
+store_response "[::1]:8082" "404"
+store_response "[::2]:8080" "000"
+store_response "[::3]:8080" "000"
+store_response "[::1]:8081" "404"
+
+# Stop the server
+echo "Stopping the server..."
+kill $SERVER_PID
+
+# Print all responses
+echo "Test results:"
+cat results.txt
+rm results.txt
+
+echo "Test script completed."

--- a/tests/multi_sockets/testIPv4.sh
+++ b/tests/multi_sockets/testIPv4.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if the webserv binary exists
+if [ ! -f ./../../webserv ]; then
+    echo -e "${RED}Error: webserv binary not found!${NC}"
+    exit 1
+fi
+
+echo "Starting test script..."
+
+# Modify /etc/hosts to add the new localhost aliases
+echo "127.0.0.2 localhost2" >> /etc/hosts
+echo "127.0.0.3 localhost3" >> /etc/hosts
+
+# Start the server
+echo "Starting the server..."
+./../../webserv ./../../multiIPv4.conf &
+SERVER_PID=$!
+sleep 2  # Wait for the server to start
+
+# Check if the server started successfully
+if ! ps -p $SERVER_PID > /dev/null; then
+    echo -e "${RED}Failed to start the server.${NC}"
+    exit 1
+fi
+
+# Function to store response
+store_response() {
+    local url=$1
+    local expected=$2
+    local response=$(curl -s -o /dev/null -w "%{http_code}" $url)
+    if [ "$response" == "$expected" ]; then
+        echo -e "$url - Expected $expected - HTTP status code: $response ${GREEN}✔${NC}" >> results.txt
+    else
+        echo -e "$url - Expected $expected - HTTP status code: $response ${RED}✘${NC}" >> results.txt
+    fi
+}
+
+# Run curl commands and store responses
+store_response "127.0.0.1:8080" "404"
+store_response "0.0.0.0:8081" "404"
+store_response "127.0.0.1:8082" "404"
+store_response "127.0.0.2:8080" "000"
+store_response "127.0.0.3:8080" "000"
+store_response "127.0.0.1:8081" "404"
+
+# Stop the server
+echo "Stopping the server..."
+kill $SERVER_PID
+
+# Print all responses
+echo "Test results:"
+cat results.txt
+rm results.txt
+
+echo "Test script completed."

--- a/tests/multi_sockets/testIPv6.sh
+++ b/tests/multi_sockets/testIPv6.sh
@@ -14,12 +14,12 @@ fi
 echo "Starting test script..."
 
 # Modify /etc/hosts to add the new localhost aliases
-echo "127.0.0.2 localhost2" >> /etc/hosts
-echo "127.0.0.3 localhost3" >> /etc/hosts
+echo "::2 localhost2" >> /etc/hosts
+echo "::3 localhost3" >> /etc/hosts
 
 # Start the server
 echo "Starting the server..."
-./../../webserv ./../../multi.conf &
+./../../webserv ./../../multiIPv6.conf &
 SERVER_PID=$!
 sleep 2  # Wait for the server to start
 
@@ -42,12 +42,12 @@ store_response() {
 }
 
 # Run curl commands and store responses
-store_response "127.0.0.1:8080" "404"
-store_response "0.0.0.0:8081" "404"
-store_response "127.0.0.1:8082" "404"
-store_response "127.0.0.2:8080" "000"
-store_response "127.0.0.3:8080" "000"
-store_response "127.0.0.1:8081" "404"
+store_response "[::1]:8080" "404"
+store_response "[::]:8081" "404"
+store_response "[::1]:8082" "404"
+store_response "[::2]:8080" "000"
+store_response "[::3]:8080" "000"
+store_response "[::1]:8081" "404"
 
 # Stop the server
 echo "Stopping the server..."

--- a/tests/multi_sockets/testIPv6.sh
+++ b/tests/multi_sockets/testIPv6.sh
@@ -5,6 +5,12 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+# Install net-tools if not present
+if ! command -v netstat &> /dev/null; then
+    echo "Installing net-tools..."
+    apt-get update && apt-get install -y net-tools
+fi
+
 # Check if the webserv binary exists
 if [ ! -f ./../../webserv ]; then
     echo -e "${RED}Error: webserv binary not found!${NC}"
@@ -29,6 +35,18 @@ if ! ps -p $SERVER_PID > /dev/null; then
     exit 1
 fi
 
+# Verify server is listening on the expected address and port
+echo "Checking server listening ports..."
+netstat -tuln | grep 8081 >> netstat_results.txt
+netstat -tuln | grep 8080 >> netstat_results.txt
+netstat -tuln | grep 8082 >> netstat_results.txt
+
+# Check IPv6 configuration
+echo "IPv6 configuration:"
+ip -6 addr > ipv6_config.txt
+ip -6 route >> ipv6_config.txt
+
+
 # Function to store response
 store_response() {
     local url=$1
@@ -43,7 +61,8 @@ store_response() {
 
 # Run curl commands and store responses
 store_response "[::1]:8080" "404"
-store_response "[::]:8081" "404"
+# store_response "[::]:8081" "404"
+store_response "[::0]:8081" "404"
 store_response "[::1]:8082" "404"
 store_response "[::2]:8080" "000"
 store_response "[::3]:8080" "000"
@@ -57,5 +76,17 @@ kill $SERVER_PID
 echo "Test results:"
 cat results.txt
 rm results.txt
+
+# Print netstat results
+echo "Netstat results:"
+cat netstat_results.txt
+rm netstat_results.txt
+
+# Print IPv6 configuration
+echo "IPv6 configuration:"
+cat ipv6_config.txt
+rm ipv6_config.txt
+
+
 
 echo "Test script completed."

--- a/tests/multi_sockets/test_mixed.sh
+++ b/tests/multi_sockets/test_mixed.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if the webserv binary exists
+if [ ! -f ./../../webserv ]; then
+    echo -e "${RED}Error: webserv binary not found!${NC}"
+    exit 1
+fi
+
+echo "Starting test script..."
+
+# Modify /etc/hosts to add the new localhost aliases
+echo "127.0.0.2 localhost2" >> /etc/hosts
+echo "127.0.0.3 localhost3" >> /etc/hosts
+echo "::2 localhost2" >> /etc/hosts
+echo "::3 localhost3" >> /etc/hosts
+
+# Start the server
+echo "Starting the server..."
+./../../webserv ./../../multiIPv4+IPv6.conf &
+SERVER_PID=$!
+sleep 2  # Wait for the server to start
+
+# Check if the server started successfully
+if ! ps -p $SERVER_PID > /dev/null; then
+    echo -e "${RED}Failed to start the server.${NC}"
+    exit 1
+fi
+
+# Function to store response
+store_response() {
+    local url=$1
+    local expected=$2
+    local response=$(curl -s -o /dev/null -w "%{http_code}" $url)
+    if [ "$response" == "$expected" ]; then
+        echo -e "$url - Expected $expected - HTTP status code: $response ${GREEN}✔${NC}" >> results.txt
+    else
+        echo -e "$url - Expected $expected - HTTP status code: $response ${RED}✘${NC}" >> results.txt
+    fi
+}
+
+# Run curl commands and store responses
+store_response "0.0.0.0:8081" "404"
+store_response "127.0.0.2:8080" "000"
+store_response "127.0.0.3:8080" "000"
+store_response "[::1]:8080" "404"
+store_response "[::]:8081" "404"
+store_response "[::1]:8082" "404"
+store_response "[::2]:8080" "000"
+store_response "[::3]:8080" "000"
+store_response "[::1]:8081" "404"
+
+# Stop the server
+echo "Stopping the server..."
+kill $SERVER_PID
+
+# Print all responses
+echo "Test results:"
+cat results.txt
+rm results.txt
+
+echo "Test script completed."


### PR DESCRIPTION
This has tests now also for IPv6. 
IPv6 needs to be enabled in Docker though. 
In the Markdown the are instructions on how to do it. 

We have 4 different scripts. 3 out of 4 are working, the last not, cause the config parser is not happy with the one with the mixed addresses with the same port. Anyway the server is definetevly working with multiple ip:ports combination (with different server sockets) for Ipv4 and IPv6. 

IPv6 was not even part of the subject btw. 