### PR TITLE
Prevent firefox to send background requests to services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 !**/*.jpg
 !**/*.yml
 !**/*.csv
+!**/*.cfg
+!**/*.js
 
 # Specific files and directories to include
 !Makefile

--- a/docs/firefox/firefox.cfg
+++ b/docs/firefox/firefox.cfg
@@ -1,0 +1,49 @@
+// Disable Captive Portal Detection
+pref("network.captive-portal-service.enabled", false);
+
+// Disable Firefox Health Report
+pref("datareporting.healthreport.uploadEnabled", false);
+
+// Disable Telemetry
+pref("toolkit.telemetry.enabled", false);
+pref("toolkit.telemetry.unified", false);
+pref("toolkit.telemetry.archive.enabled", false);
+
+// Disable Prefetching
+pref("network.prefetch-next", false);
+
+// Disable DNS Prefetching
+pref("network.dns.disablePrefetch", true);
+pref("network.dns.disablePrefetchFromHTTPS", true);
+
+// Disable Speculative Connections
+pref("network.http.speculative-parallel-limit", 0);
+
+// Disable Browser Safebrowsing
+pref("browser.safebrowsing.enabled", false);
+pref("browser.safebrowsing.malware.enabled", false);
+
+// Disable Firefox Studies
+pref("app.shield.optoutstudies.enabled", false);
+
+// Disable Extension Recommendations
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr", false);
+
+// Disable Pocket
+pref("extensions.pocket.enabled", false);
+
+// Additional Settings from the Article
+pref("browser.aboutHomeSnippets.updateUrl", ""); // Disable Snippets
+pref("app.update.auto", false); // Disable Automatic Browser Updates
+pref("app.update.enabled", false);
+pref("browser.search.update", false);
+pref("extensions.update.enabled", false); // Disable Automatic Add-on Updates
+pref("extensions.blocklist.enabled", false); // Disable Blocklist Updates
+pref("browser.safebrowsing.downloads.remote.enabled", false); // Disable Malware Protection
+pref("privacy.trackingprotection.enabled", false); // Disable Tracking Protection
+pref("security.OCSP.enabled", 0); // Disable TLS/SSL Certificate Revocation Check
+pref("browser.search.geoip.url", ""); // Disable GeoIP Lookup
+pref("browser.startup.homepage_override.mstone", "ignore"); // Disable "What's New" Page
+pref("extensions.getAddons.cache.enabled", false); // Disable Add-on Recommendations
+pref("datareporting.policy.dataSubmissionEnabled", false); // Disable Firefox Diagnostic Data
+pref("browser.selfsupport.enabled", false); // Disable Survey Sampling

--- a/docs/firefox/firefox.md
+++ b/docs/firefox/firefox.md
@@ -1,0 +1,33 @@
+# Firefox Shut up Configuration
+
+To apply custom preferences in Firefox and minimize unwanted background requests, follow these steps:
+
+## Step 1: Create the Configuration File
+
+1. Create a JavaScript file named `firefox.cfg`.
+2. Add your desired configuration settings to this file. (See the provided `firefox.cfg` file content for reference.)
+
+## Step 2: Create a Local Configuration File
+
+1. Create another JavaScript file named `local-settings.js`.
+2. Add the following content to `local-settings.js` to specify the configuration file:
+
+   ```javascript
+   // local-settings.js
+   pref("general.config.filename", "firefox.cfg");
+   pref("general.config.obscure_value", 0); // Use 0 to disable byte-shifting
+   ```
+
+## Step 3: Place the Files in the Correct Directories
+
+1. Locate the root directory of your Firefox installation. On Windows, this is typically `C:\Program Files\Mozilla Firefox`. On macOS and Linux, it may vary.
+2. Place `firefox.cfg` in the root directory of the Firefox installation.
+3. Place `local-settings.js` in the `defaults/pref` directory within the Firefox installation directory.
+
+   - **Windows Example:**
+     - `firefox.cfg` -> `C:\Program Files\Mozilla Firefox\firefox.cfg`
+     - `local-settings.js` -> `C:\Program Files\Mozilla Firefox\defaults\pref\local-settings.js`
+
+## Step 4: Restart Firefox
+
+After placing these files in the correct directories, restart Firefox. It should now load the preferences specified in your `firefox.cfg` file.

--- a/docs/firefox/local-settings.js
+++ b/docs/firefox/local-settings.js
@@ -1,0 +1,3 @@
+// local-settings.js
+pref("general.config.filename", "firefox.cfg");
+pref("general.config.obscure_value", 0); // Use 0 to disable byte-shifting


### PR DESCRIPTION
Some configuration file and docs to avoid firefox to send all these background requests.

I found also an interesting article about it: https://www.secureideas.com/blog/2018/10/silencing-firefoxs-chattiness-for-web-app-testing.html

Firefox should then not be used for normal browsing with this config. 